### PR TITLE
Introduce --remove-all option

### DIFF
--- a/alternatives.8
+++ b/alternatives.8
@@ -49,6 +49,11 @@ alternatives \- maintain symbolic links determining default commands
 .RI [ options ]
 .B --list
 .I name
+.PP
+.B alternatives
+.RI [ options ]
+.B --remove-all
+.I name
 .SH DESCRIPTION
 .B alternatives
 creates, removes, maintains and displays information about the symbolic
@@ -374,6 +379,9 @@ and the highest priority alternative currently installed.
 .TP
 \fB--list \fR
 Display information about all link groups.
+.TP
+\fB--remove-all\fR \fIname\fR
+Remove the whole link group \fIname\fR. Use with caution.
 .SH FILES
 .TP
 .I /etc/alternatives/

--- a/alternatives.c
+++ b/alternatives.c
@@ -77,6 +77,7 @@ static int usage(int rc) {
     printf(_("       alternatives --display <name>\n"));
     printf(_("       alternatives --set <name> <path>\n"));
     printf(_("       alternatives --list\n"));
+    printf(_("       alternatives --remove-all <name>\n"));
     printf(_("\n"));
     printf(_("common options: --verbose --test --help --usage --version --keep-missing\n"));
     printf(_("                --altdir <directory> --admindir <directory>\n"));

--- a/alternatives.c
+++ b/alternatives.c
@@ -60,7 +60,7 @@ struct alternativeSet {
     char * currentLink;
 };
 
-enum programModes { MODE_UNKNOWN, MODE_INSTALL, MODE_REMOVE, MODE_AUTO,
+enum programModes { MODE_UNKNOWN, MODE_INSTALL, MODE_REMOVE, MODE_REMOVE_ALL, MODE_AUTO,
 		    MODE_DISPLAY, MODE_CONFIG, MODE_SET,
 		    MODE_SLAVE, MODE_VERSION, MODE_USAGE, MODE_LIST };
 
@@ -926,6 +926,21 @@ static int removeService(const char * title, const char * target,
     return 0;
 }
 
+
+static int removeAll(const char * title, const char * altDir, const char * stateDir, int flags) {
+    struct alternativeSet set;
+
+    int alt;
+
+    if (readConfig(&set, title, altDir, stateDir, flags)) return 2;
+
+    for (alt = 0; alt < set.numAlts; alt++) {
+        removeService(title, set.alts[alt].master.target, altDir, stateDir, flags);
+    }
+
+    return 0;
+}
+
 static int listServices(const char * altDir, const char * stateDir, int flags) {
         DIR *dir;
         struct dirent *ent;
@@ -1012,6 +1027,8 @@ int main(int argc, const char ** argv) {
 	    nextArg++;
 	} else if (!strcmp(*nextArg, "--remove")) {
 	    setupDoubleArg(&mode, &nextArg, MODE_REMOVE, &title, &target);
+	} else if (!strcmp(*nextArg, "--remove-all")) {
+	    setupSingleArg(&mode, &nextArg, MODE_REMOVE_ALL, &title);
 	} else if (!strcmp(*nextArg, "--set")) {
 	    setupDoubleArg(&mode, &nextArg, MODE_SET, &title, &target);
 	} else if (!strcmp(*nextArg, "--auto")) {
@@ -1089,6 +1106,8 @@ int main(int argc, const char ** argv) {
 	return setService(title, target, altDir, stateDir, flags);
       case MODE_REMOVE:
 	return removeService(title, target, altDir, stateDir, flags);
+      case MODE_REMOVE_ALL:
+	return removeAll(title, altDir, stateDir, flags);
       case MODE_SLAVE:
 	usage(2);
       case MODE_LIST:

--- a/alternatives.c
+++ b/alternatives.c
@@ -932,14 +932,15 @@ static int removeAll(const char * title, const char * altDir, const char * state
     struct alternativeSet set;
 
     int alt;
+    int ret_val = 0;
 
     if (readConfig(&set, title, altDir, stateDir, flags)) return 2;
 
     for (alt = 0; alt < set.numAlts; alt++) {
-        removeService(title, set.alts[alt].master.target, altDir, stateDir, flags);
+        ret_val += removeService(title, set.alts[alt].master.target, altDir, stateDir, flags);
     }
 
-    return 0;
+    return (ret_val > 1) ? 2 : 0;
 }
 
 static int listServices(const char * altDir, const char * stateDir, int flags) {


### PR DESCRIPTION
This option is supposed to be used when user wants to delete all alternatives. e.g. when you want to change the **link** (alternatives --install \<link\> \<name\> \<path\> \<priority\>).

State of this PR: just preview of intended functionality