### PR TITLE
Fix issues with extra backslashes in path string

### DIFF
--- a/alternatives.c
+++ b/alternatives.c
@@ -255,6 +255,25 @@ char *parseLine(char **buf) {
     return strdup(start);
 }
 
+/* Function to clean path form unnecessary backslashes
+ * It will make from //abcd///efgh/ -> /abcd/efgh/
+ */
+void clean_path(char *path) {
+    char *pr = path;  // reading pointer
+    char *pw = path;  // writing pointer
+  
+    while (*pr) {
+        *pw = *pr;
+        pr++;
+        if ((*pw == '/') && (*pr != '/')) {
+            pw++;
+        } else if (*pw != '/') {
+            pw++;
+        }
+    }
+    *pw = '\0';
+}
+
 static int readConfig(struct alternativeSet *set, const char *title,
                       const char *altDir, const char *stateDir, int flags) {
     char *path;
@@ -279,6 +298,8 @@ static int readConfig(struct alternativeSet *set, const char *title,
 
     path = alloca(strlen(stateDir) + strlen(title) + 2);
     sprintf(path, "%s/%s", stateDir, title);
+
+    clean_path(path);
 
     if (FL_VERBOSE(flags))
         printf(_("reading %s\n"), path);


### PR DESCRIPTION
From `/abc//def/` to `/abc/def/`

Resolve: #1485304