### PR TITLE
alternatives setService(): Add missing error mesg

### DIFF
--- a/alternatives.c
+++ b/alternatives.c
@@ -1048,10 +1048,16 @@ static int setService(const char *title, const char *target, const char *altDir,
                       const char *stateDir, int flags) {
     struct alternativeSet set;
     int found = -1;
-    int i;
+    int i, r;
 
-    if (readConfig(&set, title, altDir, stateDir, flags))
+    r = readConfig(&set, title, altDir, stateDir, flags);
+    if (r) {
+        if (r == 3) {
+            fprintf(stderr,
+                _("cannot access %s/%s: No such file or directory\n"), stateDir, title);
+        }
         return 2;
+    }
 
     for (i = 0; i < set.numAlts; i++)
         if (!strcmp(set.alts[i].master.target, target)) {


### PR DESCRIPTION
You will get this mesg when trying to do:
\# alternatives --set python /usr/bin/python2
When there is no python2, you'll get error 2 plus error mesg added by
this patch

Resolves: #1820089