### PR TITLE
Fixing typos

### DIFF
--- a/chkconfig.spec
+++ b/chkconfig.spec
@@ -359,7 +359,7 @@ rm -rf $RPM_BUILD_ROOT
 * Fri Jun  4 2004 Bill Nottingham <notting@redhat.com> 1.3.11-1
 - fix LSB comment parsing (#85678)
 
-* Wed May 29 2004 Bill Nottingham <notting@redhat.com> 1.3.10-1
+* Sat May 29 2004 Bill Nottingham <notting@redhat.com> 1.3.10-1
 - mark alternatives help output for translation (#110526)
 
 * Wed Oct 22 2003 Bill Nottingham <notting@redhat.com> 1.3.9-1
@@ -429,7 +429,7 @@ rm -rf $RPM_BUILD_ROOT
 * Sun Jan 27 2002 Erik Troan <ewt@redhat.com>
 - reimplemented update-alternatives as just alternatives
 
-* Thu Jan 25 2002 Bill Nottingham <notting@redhat.com>
+* Fri Jan 25 2002 Bill Nottingham <notting@redhat.com>
 - add in update-alternatives stuff (perl ATM)
 
 * Mon Aug 27 2001 Trond Eivind Glomsrød <teg@redhat.com>
@@ -474,10 +474,10 @@ rm -rf $RPM_BUILD_ROOT
 * Sun Aug 20 2000 Matt Wilson <msw@redhat.com>
 - new translations
 
-* Tue Aug 16 2000 Nalin Dahyabhai <nalin@redhat.com>
+* Wed Aug 16 2000 Nalin Dahyabhai <nalin@redhat.com>
 - don't worry about extra whitespace on chkconfig: lines (#16150)
 
-* Wed Aug 10 2000 Trond Eivind Glomsrød <teg@redhat.com>
+* Thu Aug 10 2000 Trond Eivind Glomsrød <teg@redhat.com>
 - i18n merge
 
 * Wed Jul 26 2000 Matt Wilson <msw@redhat.com>

--- a/po/fur.po
+++ b/po/fur.po
@@ -463,7 +463,7 @@ msgstr ""
 #: ../alternatives.c:565
 #, c-format
 msgid "%s already exists\n"
-msgstr "%s al esist za"
+msgstr "%s al esist za\n"
 
 #: ../alternatives.c:567
 #, c-format


### PR DESCRIPTION
fur.po: missing "\n" - blocks build
changelog: bogus dates