### PR TITLE
Fix spelling of SELinux

### DIFF
--- a/leveldb.c
+++ b/leveldb.c
@@ -898,7 +898,7 @@ int setXinetdService(struct service s, int on) {
     unlink(oldfname);
     r = rename(newfname, oldfname);
     if (selinux_restore(oldfname) != 0)
-        fprintf(stderr, _("Unable to set selinux context for %s: %s\n"),
+        fprintf(stderr, _("Unable to set SELinux context for %s: %s\n"),
                 oldfname, strerror(errno));
     return (r);
 }


### PR DESCRIPTION
(cherry picked from commit 88c4e04c6aa1555980614717b7e2d4e39ed46598)