### PR TITLE
spec: sync specfile with Fedora

### DIFF
--- a/chkconfig.spec
+++ b/chkconfig.spec
@@ -5,7 +5,6 @@ Release: 1%{?dist}
 License: GPLv2
 URL: https://github.com/fedora-sysv/chkconfig
 Source: https://github.com/fedora-sysv/chkconfig/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires: newt-devel gettext popt-devel libselinux-devel beakerlib gcc systemd-devel make
 Conflicts: initscripts <= 5.30-1
 


### PR DESCRIPTION
Remove obsolete BuildRoot tag