### PR TITLE
alternatives: add --keep-foreign

### DIFF
--- a/alternatives.8
+++ b/alternatives.8
@@ -270,6 +270,10 @@ this is (and give some usage information).
 When switching between alternatives, if the new variant does not provide some files, keep the links pointed to the previous implementation.
 It prevents issues with missing files due to switching between versions.
 .TP
+.B --keep-foreign
+When removing, adding or switching between alternatives, check if the facility does not point to some other location than altdir.
+In such case the link is not modified.
+.TP
 \fB--altdir\fR \fIdirectory\fR
 Specifies the alternatives directory, when this is to be
 different from the default.


### PR DESCRIPTION
Right now when we are switching between alternatives or removing them,
we check if the facility (the path what user is using) is a symlink and
only refuse to remove it if it is an binary.

This commit add options --keep-foreign. With this option, alternatives
will check if the facility does not point to some other location than
altdir.