### PR TITLE
spec: Replace not working awk command with sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $(shell awk '/Version:/ { print $$2 }' chkconfig.spec)
-NEXT_VERSION := $(shell awk '/Version:/ { print $$2 + 0.01 }' chkconfig.spec)
+NEXT_VERSION := $(shell sed -nr 's/Version:[ ]*([0-9]*)\.([0-9]*)\.([0-9]*)/echo "\1\.\2\.$$((\3+1))"/gep' chkconfig.spec)
 TAG = $(VERSION)
 
 CFLAGS = -g -Wall $(RPM_OPT_FLAGS) -D_GNU_SOURCE


### PR DESCRIPTION
Sed command get version number from spec file and increment last
number by one. Work like old awk command was intended to work.

Old: 10.09 -> 10.1
New: 10.09 -> 10.10

Source: https://stackoverflow.com/questions/14348432/how-to-find-replace-and-increment-a-matched-number-with-sed-awk/14348899

(cherry picked from commit 37f4784a164e7b7fdc8250e606bd94fc36103549)