### PR TITLE
Fix systemdActive()

### DIFF
--- a/leveldb.c
+++ b/leveldb.c
@@ -946,13 +946,7 @@ int systemdIsInit() {
 }
 
 int systemdActive() {
-    struct stat a, b;
-
-    if (lstat("/sys/fs/cgroup", &a) < 0)
-        return 0;
-    if (lstat("/sys/fs/cgroup/systemd", &b) < 0)
-        return 0;
-    if (a.st_dev == b.st_dev)
+    if (access("/run/systemd/system/", F_OK) < 0)
         return 0;
     if (!systemdIsInit())
         return 0;


### PR DESCRIPTION
/sys/fs/cgroup/systemd is long gone:

https://systemd.io/CGROUP_DELEGATION/

Check for /run/systemd/system/ directory existence instead:

https://www.freedesktop.org/software/systemd/man/sd_booted.html

Closes fedora-sysv/chkconfig#116