### PR TITLE
Prepare for bin-sbin merge

### DIFF
--- a/chkconfig.spec
+++ b/chkconfig.spec
@@ -35,6 +35,11 @@ page), ntsysv configures the current runlevel (5 if you're using X).
 
 %package -n alternatives
 Summary: A tool to maintain symbolic links determining default commands
+%if "%{_sbindir}" == "%{_bindir}"
+Provides: /usr/sbin/alternatives
+Provides: /usr/sbin/update-alternatives
+Requires: filesystem(unmerged-sbin-symlinks)
+%endif
 
 %description -n alternatives
 alternatives creates, removes, maintains and displays information about the


### PR DESCRIPTION
https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin

Add a Provides for the old names. We rely on filesystem(unmerged-sbin-symlinks) feature to create the symlink for us.

This commit makes things compatible with the state before and after the merge.

/cc @keszybz

This PR replaces - https://src.fedoraproject.org/rpms/chkconfig/pull-request/13