### PR TITLE
ostree: move admindir to /etc/alternatives.admindir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ install:
 	[ -d $(DESTDIR)/$(SBINDIR) ] || mkdir -p $(DESTDIR)/$(SBINDIR)
 	[ -d $(DESTDIR)/$(MANDIR) ] || mkdir -p $(DESTDIR)/$(MANDIR)
 	[ -d $(DESTDIR)/$(MANDIR)/man8 ] || mkdir -p $(DESTDIR)/$(MANDIR)/man8
-	[ -d $(DESTDIR)/$(ALTDIR) ] || mkdir -p -m 755 $(DESTDIR)/$(ALTDIR)
 	[ -d $(DESTDIR)/$(ALTDATADIR) ] || mkdir -p -m 755 $(DESTDIR)/$(ALTDATADIR)
 	[ -d $(DESTDIR)/$(SYSTEMDUTILDIR) ] || mkdir -p -m 755 $(DESTDIR)/$(SYSTEMDUTILDIR)
 

--- a/alternatives.8
+++ b/alternatives.8
@@ -214,6 +214,7 @@ A directory, by default
 containing
 .BR alternatives '
 state information.
+/etc/alternatives.admindir on OSTree-based systems.
 .TP
 link group
 A set of related symlinks, intended to be updated as a group.
@@ -416,6 +417,7 @@ option.
 .TP
 .I /var/lib/alternatives/
 The default administration directory.
+/etc/alternatives.admindir on OSTree-based systems.
 Can be overridden by the
 .B --admindir
 option.

--- a/chkconfig.spec
+++ b/chkconfig.spec
@@ -19,7 +19,7 @@ Provides: /sbin/chkconfig
 %description
 Chkconfig is a basic system utility.  It updates and queries runlevel
 information for system services.  Chkconfig manipulates the numerous
-symbolic links in /etc/rc.d, to relieve system administrators of some 
+symbolic links in /etc/rc.d, to relieve system administrators of some
 of the drudgery of manually editing the symbolic links.
 
 %package -n ntsysv
@@ -95,11 +95,12 @@ mkdir -p $RPM_BUILD_ROOT/etc/chkconfig.d
 %files -n alternatives
 %license COPYING
 %dir /etc/alternatives
+%ghost %dir %attr(755, root, root) /etc/alternatives.admindir
+%ghost %dir %attr(755, root, root) /var/lib/alternatives
 %{_sbindir}/update-alternatives
 %{_sbindir}/alternatives
 %{_mandir}/*/update-alternatives*
 %{_mandir}/*/alternatives*
-%dir /var/lib/alternatives
 
 %changelog
 * Tue Jul 30 2024 Jan Macku <jamacku@redhat.com> - 1.29-1

--- a/po/chkconfig.pot
+++ b/po/chkconfig.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 12:58+0100\n"
+"POT-Creation-Date: 2024-07-26 11:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -325,259 +325,259 @@ msgstr ""
 msgid "                --altdir <directory> --admindir <directory>\n"
 msgstr ""
 
-#: ../alternatives.c:293
+#: ../alternatives.c:311
 #, c-format
 msgid "reading %s\n"
 msgstr ""
 
-#: ../alternatives.c:298
+#: ../alternatives.c:316
 #, c-format
 msgid "failed to open %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:306
+#: ../alternatives.c:324
 #, c-format
 msgid "failed to read %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:314
+#: ../alternatives.c:332
 #, c-format
 msgid "%s empty!\n"
 msgstr ""
 
-#: ../alternatives.c:323
+#: ../alternatives.c:342
 #, c-format
 msgid "bad mode on line 1 of %s\n"
 msgstr ""
 
-#: ../alternatives.c:330
+#: ../alternatives.c:349
 #, c-format
 msgid "bad primary link in %s\n"
 msgstr ""
 
-#: ../alternatives.c:342
+#: ../alternatives.c:362
 #, c-format
 msgid "path %s unexpected in %s\n"
 msgstr ""
 
-#: ../alternatives.c:351
+#: ../alternatives.c:372
 #, c-format
 msgid "missing path for follower %s in %s\n"
 msgstr ""
 
-#: ../alternatives.c:361
+#: ../alternatives.c:383
 #, c-format
 msgid "unexpected end of file in %s\n"
 msgstr ""
 
-#: ../alternatives.c:370
+#: ../alternatives.c:393
 #, c-format
 msgid "path to alternate expected in %s\n"
 msgstr ""
 
-#: ../alternatives.c:371 ../alternatives.c:397 ../alternatives.c:409
-#: ../alternatives.c:427 ../alternatives.c:447
+#: ../alternatives.c:394 ../alternatives.c:423 ../alternatives.c:436
+#: ../alternatives.c:455 ../alternatives.c:476
 #, c-format
 msgid "unexpected line in %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:395
+#: ../alternatives.c:421
 #, c-format
 msgid "closing '@' missing or the family is empty in %s\n"
 msgstr ""
 
-#: ../alternatives.c:408
+#: ../alternatives.c:435
 #, c-format
 msgid "numeric priority expected in %s\n"
 msgstr ""
 
-#: ../alternatives.c:426
+#: ../alternatives.c:454
 #, c-format
 msgid "follower path expected in %s\n"
 msgstr ""
 
-#: ../alternatives.c:456
+#: ../alternatives.c:486
 #, c-format
 msgid "failed to read link %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:472
+#: ../alternatives.c:503
 #, c-format
 msgid "link points to no alternative -- setting mode to manual\n"
 msgstr ""
 
-#: ../alternatives.c:477
+#: ../alternatives.c:508
 #, c-format
 msgid "link changed -- setting mode to manual\n"
 msgstr ""
 
-#: ../alternatives.c:517 ../alternatives.c:524
+#: ../alternatives.c:554 ../alternatives.c:561
 #, c-format
 msgid "would remove %s\n"
 msgstr ""
 
-#: ../alternatives.c:519 ../alternatives.c:528 ../alternatives.c:581
+#: ../alternatives.c:556 ../alternatives.c:565 ../alternatives.c:618
 #, c-format
 msgid "failed to remove link %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:547
+#: ../alternatives.c:584
 #, c-format
 msgid "failed to link %s -> %s: %s exists and it is not a symlink\n"
 msgstr ""
 
-#: ../alternatives.c:552
+#: ../alternatives.c:589
 #, c-format
 msgid ""
 "failed to link %s -> %s: --keep-foreign was set and link %s points outside  "
 "%s\n"
 msgstr ""
 
-#: ../alternatives.c:556 ../alternatives.c:574
+#: ../alternatives.c:593 ../alternatives.c:611
 #, c-format
 msgid "would link %s -> %s\n"
 msgstr ""
 
-#: ../alternatives.c:565 ../alternatives.c:587
+#: ../alternatives.c:602 ../alternatives.c:624
 #, c-format
 msgid "failed to link %s -> %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:620
+#: ../alternatives.c:657
 #, c-format
 msgid "%s already exists\n"
 msgstr ""
 
-#: ../alternatives.c:622
+#: ../alternatives.c:659
 #, c-format
 msgid "failed to create %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:655
+#: ../alternatives.c:692
 #, c-format
 msgid "failed to replace %s with %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:683 ../alternatives.c:689 ../alternatives.c:701
-#: ../alternatives.c:708
+#: ../alternatives.c:720 ../alternatives.c:726 ../alternatives.c:738
+#: ../alternatives.c:745
 #, c-format
 msgid "running %s\n"
 msgstr ""
 
-#: ../alternatives.c:781
+#: ../alternatives.c:818
 #, c-format
 msgid "link %s incorrect for follower %s (%s %s)\n"
 msgstr ""
 
-#: ../alternatives.c:855 ../alternatives.c:892 ../alternatives.c:1106
-#: ../alternatives.c:1137
+#: ../alternatives.c:893 ../alternatives.c:930 ../alternatives.c:1144
+#: ../alternatives.c:1175
 #, c-format
 msgid "%s has not been configured as an alternative for %s\n"
 msgstr ""
 
-#: ../alternatives.c:873
+#: ../alternatives.c:911
 #, c-format
 msgid "%s has not been configured as an follower alternative for %s (%s)\n"
 msgstr ""
 
-#: ../alternatives.c:931
+#: ../alternatives.c:969
 #, c-format
 msgid "the primary link for %s must be %s\n"
 msgstr ""
 
-#: ../alternatives.c:983
+#: ../alternatives.c:1021
 #, c-format
 msgid "%s - status is auto.\n"
 msgstr ""
 
-#: ../alternatives.c:985
+#: ../alternatives.c:1023
 #, c-format
 msgid "%s - status is manual.\n"
 msgstr ""
 
-#: ../alternatives.c:987
+#: ../alternatives.c:1025
 #, c-format
 msgid " link currently points to %s\n"
 msgstr ""
 
-#: ../alternatives.c:992
+#: ../alternatives.c:1030
 #, c-format
 msgid "family %s "
 msgstr ""
 
-#: ../alternatives.c:993
+#: ../alternatives.c:1031
 #, c-format
 msgid "priority %d\n"
 msgstr ""
 
-#: ../alternatives.c:995
+#: ../alternatives.c:1033
 #, c-format
 msgid " follower %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:1000
+#: ../alternatives.c:1038
 #, c-format
 msgid "Current `best' version is %s.\n"
 msgstr ""
 
-#: ../alternatives.c:1035
+#: ../alternatives.c:1073
 #, c-format
 msgid "There is %d program that provides '%s'.\n"
 msgstr ""
 
-#: ../alternatives.c:1036
+#: ../alternatives.c:1074
 #, c-format
 msgid "There are %d programs which provide '%s'.\n"
 msgstr ""
 
-#: ../alternatives.c:1040
+#: ../alternatives.c:1078
 #, c-format
 msgid "  Selection    Command\n"
 msgstr ""
 
-#: ../alternatives.c:1055
+#: ../alternatives.c:1093
 #, c-format
 msgid "Enter to keep the current selection[+], or type selection number: "
 msgstr ""
 
-#: ../alternatives.c:1059
+#: ../alternatives.c:1097
 #, c-format
 msgid ""
 "\n"
 "error reading choice\n"
 msgstr ""
 
-#: ../alternatives.c:1086
+#: ../alternatives.c:1124
 #, c-format
 msgid "cannot access %s/%s: No such file or directory\n"
 msgstr ""
 
-#: ../alternatives.c:1153
+#: ../alternatives.c:1191
 #, c-format
 msgid "(would remove %s\n"
 msgstr ""
 
-#: ../alternatives.c:1155
+#: ../alternatives.c:1193
 #, c-format
 msgid "failed to remove %s: %s\n"
 msgstr ""
 
-#: ../alternatives.c:1323
+#: ../alternatives.c:1365
 #, c-format
 msgid "--family can't contain the symbol '@'\n"
 msgstr ""
 
-#: ../alternatives.c:1385
+#: ../alternatives.c:1427
 #, c-format
 msgid "altdir %s invalid\n"
 msgstr ""
 
-#: ../alternatives.c:1390
+#: ../alternatives.c:1432
 #, c-format
 msgid "admindir %s invalid\n"
 msgstr ""
 
-#: ../alternatives.c:1400
+#: ../alternatives.c:1442
 #, c-format
 msgid "alternatives version %s\n"
 msgstr ""


### PR DESCRIPTION
`ostree container commit` wipes /var and thereby erases the data in /var/lib/alternatives; the directory used to store configs/symlinks of alternatives.

/var is not a good place for storing such configs since it won't receive updates on bootc images either.  We need to move to another location.

Hence, use /etc/alternatives.admindir when running on an ostree-based system unless /var/lib/alternatives is already present; a user may have worked around the problem.  This way we enable alternatives to work on ostree-based systems without breaking backwards compat.

Fixes: #9