### PR TITLE
Allow paths with /usr/sbin and /usr/bin as equivalent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SUBDIRS = po
 OBJS = chkconfig.o leveldb.o
 NTOBJS = ntsysv.o leveldb.o
 
+MERGED_SBIN ?= 0
+
 all: subdirs $(PROG) ntsysv alternatives
 
 subdirs:
@@ -36,7 +38,7 @@ chkconfig.o: chkconfig.c leveldb.h
 	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" -c chkconfig.c
 
 alternatives.o: alternatives.c
-	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" -c alternatives.c
+	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" -DMERGED_SBIN=$(MERGED_SBIN) -c alternatives.c
 
 ntsysv.o: ntsysv.c leveldb.h
 	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" -c ntsysv.c

--- a/chkconfig.spec
+++ b/chkconfig.spec
@@ -12,6 +12,8 @@ BuildRequires: gcc gettext libselinux-devel make newt-devel popt-devel pkgconfig
 BuildRequires: beakerlib
 %endif
 
+%global merged_sbin %["%{_sbindir}" == "%{_bindir}"]
+
 Conflicts: initscripts <= 5.30-1
 
 Provides: /sbin/chkconfig
@@ -35,7 +37,7 @@ page), ntsysv configures the current runlevel (5 if you're using X).
 
 %package -n alternatives
 Summary: A tool to maintain symbolic links determining default commands
-%if "%{_sbindir}" == "%{_bindir}"
+%if %{merged_sbin}
 Provides: /usr/sbin/alternatives
 Provides: /usr/sbin/update-alternatives
 Requires: filesystem(unmerged-sbin-symlinks)
@@ -51,7 +53,7 @@ system at the same time.
 %setup -q
 
 %build
-%make_build RPM_OPT_FLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS"
+%make_build RPM_OPT_FLAGS="$RPM_OPT_FLAGS" LDFLAGS="$RPM_LD_FLAGS" MERGED_SBIN=%{merged_sbin}
 
 # tests are executed using tmt and tf on CentOS Stream and RHEL
 %if 0%{?fedora}


### PR DESCRIPTION
After https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin, various rpms change paths from /usr/sbin to /usr/bin. If we're built in an environment where %_sbindir==%_bindir, allow paths to differ in the prefix.

Tested by reverting the patch to move paths in iptables-legacy back to /usr/sbin [1]. The subsequent rpm installs fine both when /usr/sbin is a symlink (new installs) and a directory (upgrades).

This approach is bit of a hack, but it also seems quite safe, because it doesn't change the stored data in any way, it just suppresses two error checks.

[1] https://src.fedoraproject.org/rpms/iptables/c/43696a4be35ecb64b596d1db368cb736a91316e8