### PR TITLE
ci: fix Differential ShellCheck workflow

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ main, rhel*-branch ]
   pull_request:
     branches: [ main, rhel*-branch ]
 


### PR DESCRIPTION
```
Warning:  git: base SHA1 (0000000000000000000000000000000000000000) doesn't exist. Make sure that the base branch is up-to-date.
```